### PR TITLE
fix: coerce integer and logical objective returns to double in batch mode

### DIFF
--- a/src/cmaes_wrap.cpp
+++ b/src/cmaes_wrap.cpp
@@ -48,6 +48,12 @@ SEXP call_obj_with_error_handling_PROTECT(SEXP s_obj, SEXP s_x, R_xlen_t lambda)
     throw libcmaesr_error(libcmaesr_errcode::eval_failed, "libcmaesr: objective evaluation failed!");
   }
   check_numvec(s_y, lambda);
+  // coerce integer/logical returns to double, downstream code assumes REALSXP
+  if (TYPEOF(s_y) != REALSXP) {
+    SEXP s_y_real = PROTECT(Rf_coerceVector(s_y, REALSXP));
+    UNPROTECT(2); // s_y_real, s_y; re-protect below, no allocation in between
+    s_y = PROTECT(s_y_real);
+  }
   return s_y;
 }
 

--- a/tests/testthat/test_batch.R
+++ b/tests/testthat/test_batch.R
@@ -248,6 +248,17 @@ test_that("batch: objective must return numeric vector (type check)", {
   )
 })
 
+test_that("batch: objective may return an integer vector", {
+  dim = 2
+  fn = function(x) rep(1L, nrow(x))
+  x0 = rep(0.5, dim)
+  lower = rep(-1, dim)
+  upper = rep(1, dim)
+  ctrl = cmaes_control(lambda = 4, max_fevals = 8, seed = 1)
+  res = cmaes(fn, x0, lower, upper, ctrl, batch = TRUE)
+  expect_identical(res$y, 1)
+})
+
 test_that("batch: objective must return vector of length lambda (length check)", {
   dim = 3
   lambda = 5

--- a/tests/testthat/test_single.R
+++ b/tests/testthat/test_single.R
@@ -241,6 +241,17 @@ test_that("single: objective must return numeric scalar (type check)", {
   )
 })
 
+test_that("single: objective may return an integer scalar", {
+  dim = 2
+  fn = function(x) 1L
+  x0 = rep(0.5, dim)
+  lower = rep(-1, dim)
+  upper = rep(1, dim)
+  ctrl = cmaes_control(max_fevals = 5, seed = 1)
+  res = cmaes(fn, x0, lower, upper, ctrl, batch = FALSE)
+  expect_identical(res$y, 1)
+})
+
 test_that("single: objective must return length 1 (length check)", {
   dim = 2
   fn = function(x) c(1, 2) # wrong length


### PR DESCRIPTION
## Summary

In batch mode, an objective function returning an integer (or logical) vector — e.g. `function(x) rep(1L, nrow(x))` — crashed with:

```
Error: REAL() can only be applied to a 'numeric', not a 'integer'
```

`check_numvec()` validates the return value with `Rf_isNumeric()`, which accepts `INTSXP` and `LGLSXP`, but the batch path then reads it with `REAL()`, which only accepts `REALSXP`. The resulting R-internal error longjmps from inside `strat.optimize()`, skipping C++ destructors on the stack and leaving `G_IN_BATCH` stuck at `true`, which can poison a later run's cache-miss path. Single mode was unaffected (it reads via `Rf_asReal()`), so the two modes behaved inconsistently.

This is a regression: the original return-value checks in b98522d coerced non-double numeric returns with `Rf_coerceVector()`; the error-handling refactor in 57e45d0 kept the loose `Rf_isNumeric()` check but dropped the coercion.

## Fix

Restore the coercion in `call_obj_with_error_handling_PROTECT()`: after validation, non-`REALSXP` numeric returns are coerced to double, so `REAL()` is always valid downstream. The helper is shared by both modes, so batch and single mode now behave identically. PROTECT bookkeeping keeps net-one protection, so the callers' `UNPROTECT(2)` stays balanced.

## Tests

* `batch: objective may return an integer vector` (previously crashed)
* `single: objective may return an integer scalar` (regression guard)

Full suite passes: 1787 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)