### PR TITLE
fix: reset global eval cache and batch flag at start of each run

### DIFF
--- a/src/cmaes_wrap.cpp
+++ b/src/cmaes_wrap.cpp
@@ -261,6 +261,10 @@ std::pair<MyCMAParameters, MyGenoPheno> cmaes_setup(SEXP s_x0, SEXP s_lower, SEX
 
 extern "C" SEXP c_cmaes_wrap(SEXP s_obj, SEXP s_x0, SEXP s_lower, SEXP s_upper, SEXP s_ctrl, SEXP s_batch) {
   try {
+    // reset global eval state; a previous run leaves dangling cache pointers behind,
+    // and an aborted run may also leave a stale batch flag
+    G_EVAL_CACHE.clear();
+    G_IN_BATCH = false;
     std::pair<MyCMAParameters, MyGenoPheno> setup = cmaes_setup(s_x0, s_lower, s_upper, s_ctrl);
     MyCMAParameters &cmaparams = setup.first;
     MyGenoPheno &gp = setup.second;

--- a/tests/testthat/test_batch.R
+++ b/tests/testthat/test_batch.R
@@ -97,6 +97,25 @@ test_that("cmaes works with exception in objective", {
 })
 
 
+test_that("batch run after an errored batch run works", {
+  dim = 2
+  x0 = rep(0.5, dim)
+  lower = rep(-1, dim)
+  upper = rep(1, dim)
+  ctrl = cmaes_control(lambda = 4, max_fevals = 20, seed = 1, elitism = 1L)
+
+  fn_err = function(x) stop("boom")
+  capture.output(type = "message", {
+    expect_error(cmaes(fn_err, x0, lower, upper, ctrl, batch = TRUE), regexp = "evaluation failed")
+  })
+
+  fn = function(x) apply(x, 1, function(row) sum(row^2))
+  res = cmaes(fn, x0, lower, upper, ctrl, batch = TRUE)
+  expect_number(res$y)
+  expect_numeric(res$x, any.missing = FALSE, len = dim)
+})
+
+
 test_that("maximize works", {
   dim = 2
   obj = make_logged_sphere_batch(dim, "cmaes", lambda = NA)


### PR DESCRIPTION
## Summary

`G_EVAL_CACHE` maps phenotype column pointers to fitness values. It is cleared at the start of each batch `EvalFunc` invocation, but never when a run ends — so after `c_cmaes_wrap` returns, the cache is left full of dangling pointers into the destroyed `phenocands` matrix.

In a subsequent batch run, any `cachedFF` invocation *before* the first `EvalFunc` call (elitism reinjection, uncertainty-handling re-evaluations) performs a lookup against those dangling keys. If the allocator reused one of the addresses, the lookup false-hits and silently returns a stale fitness value from the *previous* optimization. Low probability, but the consequence is a silently wrong result with no error.

Additionally, a run aborted by an R-level `longjmp` while `strat.eval` is executing can leave `G_IN_BATCH` stuck at `true`, which turns legitimate cache misses in a later run into spurious "cache miss in batch mode (pointer mismatch)" errors.

## Fix

Clear `G_EVAL_CACHE` and reset `G_IN_BATCH` at the top of `c_cmaes_wrap`, so every run starts from clean global eval state regardless of how the previous run ended.

## Tests

Adds `batch run after an errored batch run works`: an errored batch run followed by a successful batch run with elitism, encoding the contract that global state does not leak across calls. (The dangling-pointer false-hit itself depends on allocator address reuse and cannot be triggered deterministically from R.)

Full suite passes: 1788 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)