### PR TITLE
fix: use exact matching in RC_find_name

### DIFF
--- a/src/rc_helpers.c
+++ b/src/rc_helpers.c
@@ -20,38 +20,14 @@ void RC_set_names(SEXP s_obj, R_xlen_t n, const char **names) {
   UNPROTECT(1); // s_names
 }
 
-// FIXME: bug: we only do a prefix check here.....
-/*
-#include <Rinternals.h>
-#include <string.h>
-
-R_len_t RC_find_name(SEXP x, const char *name) {
-  SEXP nm = Rf_getAttrib(x, R_NamesSymbol);
-  if (nm == R_NilValue || !Rf_isString(nm)) return -1;
-
-  const size_t nlen = strlen(name);
-  const R_len_t n = Rf_length(nm);  // use XLENGTH/R_xlen_t if you need long vectors
-
-  for (R_len_t i = 0; i < n; ++i) {
-    SEXP s = STRING_ELT(nm, i);
-    if (s == NA_STRING) continue;
-
-    // normalize to UTF-8 to avoid locale/encoding mismatches
-    const char *p = Rf_translateCharUTF8(s);
-
-    // exact match without recomputing strlen(p)
-    if (p[nlen] == '\0' && memcmp(p, name, nlen) == 0)
-      return i;
-  }
-  return -1;
-}
-
-*/
-
 R_xlen_t RC_find_name(SEXP s_obj, const char *name) {
   SEXP s_names = Rf_getAttrib(s_obj, R_NamesSymbol);
-  for (R_xlen_t i = 0; i < Rf_length(s_names); i++) {
-    if (strncmp(CHAR(STRING_ELT(s_names, i)), name, strlen(name)) == 0) {
+  if (!Rf_isString(s_names)) return -1;
+  for (R_xlen_t i = 0; i < Rf_xlength(s_names); i++) {
+    SEXP s_name = STRING_ELT(s_names, i);
+    if (s_name == NA_STRING) continue;
+    // normalize to UTF-8 to avoid locale/encoding mismatches
+    if (strcmp(Rf_translateCharUTF8(s_name), name) == 0) {
       return i;
     }
   }

--- a/tests/testthat/test_single.R
+++ b/tests/testthat/test_single.R
@@ -146,6 +146,23 @@ test_that("single: seed reproducibility", {
   expect_false(isTRUE(all.equal(res1$x, res3$x, tolerance = 1e-12)))
 })
 
+test_that("single: control list field order does not matter", {
+  dim = 2
+  fn = function(x) sum(x^2)
+  x0 = rep(0.5, dim)
+  lower = rep(-1, dim)
+  upper = rep(1, dim)
+  ctrl = cmaes_control(max_fevals = 40, lambda = 4, seed = 3, tpa = 2, tpa_dsigma = 0.5)
+  # reversing puts "tpa_dsigma" before "tpa", a prefix-matching name lookup would hit the wrong field
+  ctrl_rev = ctrl[rev(names(ctrl))]
+  class(ctrl_rev) = class(ctrl)
+
+  res1 = cmaes(fn, x0, lower, upper, ctrl, batch = FALSE)
+  res2 = cmaes(fn, x0, lower, upper, ctrl_rev, batch = FALSE)
+  expect_equal(res1$x, res2$x)
+  expect_equal(res1$y, res2$y)
+})
+
 test_that("single: elitism and tpa options run and return valid structure", {
   dim = 2
   for (elitism in c(0L, 1L, 2L, 3L)) {


### PR DESCRIPTION
## Summary

`RC_find_name()` — the lookup behind `RC_list_get_el_by_name()` and thus behind **every** control parameter read in `cmaes_setup()` — compared names with `strncmp(stored, name, strlen(name))`, i.e. a prefix match: any stored name merely *starting with* the query matched. A `FIXME: bug` comment acknowledging this (with a corrected implementation in a comment block) sat directly above the live code.

Control lookups only worked by ordering luck: `"tpa"` happens to precede `"tpa_dsigma"` in the `cmaes_control()` list, so the `"tpa"` lookup hit the right element first. Reordering the list (or adding any field that shares a prefix with an existing one) made lookups silently read the wrong field — no error, just a misconfigured optimizer. The new regression test demonstrates this: against the old code, a field-reversed control object produces a *different optimization result* for the same seed because `"tpa"` resolves to `"tpa_dsigma"`.

The fix replaces the lookup with an exact `strcmp` on `Rf_translateCharUTF8`-normalized names (encoding-safe), skips `NA_STRING` entries, guards against a missing/non-character names attribute, and uses `Rf_xlength`. The commented-out implementation and the `FIXME` are deleted.

## Verification

```r
library(libcmaesr)
fn = function(x) sum(x^2)
ctrl = cmaes_control(max_fevals = 40, lambda = 4, seed = 3, tpa = 2, tpa_dsigma = 0.5)
# reorder fields so "tpa_dsigma" precedes "tpa"
ctrl_rev = ctrl[rev(names(ctrl))]
class(ctrl_rev) = class(ctrl)
res1 = cmaes(fn, c(0.5, 0.5), c(-1, -1), c(1, 1), ctrl)
res2 = cmaes(fn, c(0.5, 0.5), c(-1, -1), c(1, 1), ctrl_rev)
stopifnot(identical(res1$y, res2$y)) # failed before this fix
```

Added as test `single: control list field order does not matter`, verified to fail against the old implementation and pass with the fix. Full suite: 1787 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)