### PR TITLE
refactor: remove dead and incorrect transpose copy in batch eval

### DIFF
--- a/src/cmaes_wrap.cpp
+++ b/src/cmaes_wrap.cpp
@@ -91,12 +91,6 @@ template <typename Strategy> static CMASolutions run_with_batch_eval(Strategy &s
     // create lambda x dim matrix for R objective, fill with phenotype
     SEXP s_x = RC_dblmat_create_PROTECT((R_xlen_t)lambda, (R_xlen_t)dim);
 
-    // copy to R, but transposed
-    // each row of phenocands (with lambda entries), becomes a column of s_x
-    for (Eigen::Index i = 0; i < dim; ++i) {
-      std::memcpy(REAL(s_x) + i * lambda, phenocands.row(i).data(), sizeof(double) * lambda);
-    }
-
     // Column-major map over R memory, unaligned for safety
     Eigen::Map<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::ColMajor>, Eigen::Unaligned> X(
       REAL(s_x), lambda, dim);


### PR DESCRIPTION
Addresses item 5 of the package review.

`run_with_batch_eval` copied the phenotype population into the R matrix twice:

1. A hand-rolled loop doing `memcpy(REAL(s_x) + i * lambda, phenocands.row(i).data(), ...)`. A *row* of a column-major Eigen matrix is not contiguous, so this copied interleaved values rather than the intended row.
2. An `Eigen::Map` over the same R memory assigned `X = phenocands.transpose()`, which is correct and overwrites the entire buffer.

The first copy was therefore both wrong and dead. Removed it; the `Eigen::Map` assignment is unchanged and remains the sole writer.

No behavior change — verified by `devtools::test(filter = '^batch')` (890 passing, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)