### PR TITLE
refactor: use s_obj parameter instead of global in eval helper

### DIFF
--- a/src/cmaes_wrap.cpp
+++ b/src/cmaes_wrap.cpp
@@ -43,7 +43,7 @@ static inline void check_numvec(SEXP s_y, R_xlen_t expected_length) {
 
 SEXP call_obj_with_error_handling_PROTECT(SEXP s_obj, SEXP s_x, R_xlen_t lambda) {
   r_int32_t err = 0;
-  SEXP s_y = RC_tryeval_nothrow_PROTECT(G_OBJ, s_x, &err);
+  SEXP s_y = RC_tryeval_nothrow_PROTECT(s_obj, s_x, &err);
   if (err != 0) {
     throw libcmaesr_error(libcmaesr_errcode::eval_failed, "libcmaesr: objective evaluation failed!");
   }


### PR DESCRIPTION
Addresses item 6 of the package review.

`call_obj_with_error_handling_PROTECT(SEXP s_obj, ...)` accepted an objective parameter but ignored it, calling `RC_tryeval_nothrow_PROTECT(G_OBJ, ...)` instead. The batch path at `src/cmaes_wrap.cpp:101` carefully passes the closure-captured `s_obj` in the belief that it matters — it did not. The signature implied a per-call objective that was never honored, which is exactly the kind of thing that lets the global's reentrancy problem (#7) hide in plain sight.

The helper now evaluates its parameter. Behavior is unchanged today: all three call sites pass an objective that equals `G_OBJ` at the time of the call (the two remaining `G_OBJ` call sites have no other handle on the objective and are left as-is; making them reentrant is #7's job).

## Testing

- Package compiles cleanly.
- `devtools::test()`: 1792 pass, 0 fail.

No new test: the change is behavior-preserving under every current call path, so there is nothing observable to assert on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)