### PR TITLE
fix: correct x0 bounds error message wording

### DIFF
--- a/R/cmaes.R
+++ b/R/cmaes.R
@@ -260,7 +260,7 @@ cmaes = function(objective, x0, lower, upper, control = cmaes_control(), batch =
     msgs = sprintf("x0[%i] = %f is not between lower[%i] = %f and upper[%i] = %f", seq_along(x0), x0, seq_along(x0), lower, seq_along(x0), upper)
     msgs = msgs[x0 < lower | x0 > upper]
 
-    mlr3misc::stopf("'x0' must be strictly between 'lower' and 'upper'!\n%s", paste(msgs, collapse = "\n"))
+    stopf("'x0' must be between 'lower' and 'upper'!\n%s", paste(msgs, collapse = "\n"))
   }
 
   if (!is.null(control$x0_lower) && length(control$x0_lower) != length(lower)) {

--- a/tests/testthat/test_single.R
+++ b/tests/testthat/test_single.R
@@ -302,14 +302,14 @@ test_that("single: logging / capture.output works", {
   expect_true(any(grepl("CMA-ES", outp)))
 })
 
-test_that("single: x0 must be strictly between lower and upper", {
+test_that("single: x0 must be between lower and upper", {
   dim = 2
   fn = function(x) sum(x^2)
   x0 = c(0.5, 0.6, 0.7)
   lower = c(0.4, 0.5, 0.6)
   upper = c(0.6, 0.6, 0.65)
   ctrl = cmaes_control(max_fevals = 5)
-  expect_error(cmaes(fn, x0, lower, upper, ctrl, batch = FALSE), regexp = "must be strictly between")
+  expect_error(cmaes(fn, x0, lower, upper, ctrl, batch = FALSE), regexp = "must be between")
 })
 
 test_that("x0 on lower bound works", {


### PR DESCRIPTION
Addresses item 7 of the package review.

The `x0` bounds check in `cmaes()` is deliberately inclusive (`x0 >= lower`, `x0 <= upper`, per commit "allow x0 on lower and upper"), but the error message claimed `'x0' must be strictly between 'lower' and 'upper'!`. The wording is now `'x0' must be between 'lower' and 'upper'!`, and the test that asserted on the old wording was updated.

Also replaces the explicit `mlr3misc::stopf()` with the imported `stopf()`, matching the project style rule (and the plain `stop()` calls surrounding it).

Tests: `devtools::test(filter = '^single')` — 902 passing, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)