### PR TITLE
chore: remove commented-out fevals code

### DIFF
--- a/R/cmaes.R
+++ b/R/cmaes.R
@@ -230,8 +230,6 @@ print.cmaes_control = function(x, ...) {
 #'     See here: \url{https://github.com/CMA-ES/libcmaes/wiki/Optimizing-a-function}
 #'   - 'status_msg': (`character(1)`)\cr
 #'     A human-readable status message from libcmaes.
-#   - 'fevals': (`integer(1)`)\cr
-#     The number of function evaluations.
 #' @examples
 #' # minimize a simple quadratic function
 #' objective = function(x) sum(x^2)

--- a/src/cmaes_wrap.cpp
+++ b/src/cmaes_wrap.cpp
@@ -297,7 +297,9 @@ extern "C" SEXP c_cmaes_wrap(SEXP s_obj, SEXP s_x0, SEXP s_lower, SEXP s_upper, 
     best_y = cmaparams.get_maximize() ? -best_y : best_y;
 
     // copy results to R
-    // const char *res_names[] = {"x", "y", "edm", "time", "status_code", "status_msg", "fevals"};
+    // NOTE: we deliberately do not report the number of function evaluations. libcmaes returns the "best run"
+    // snapshot, whose local eval count undercounts the total whenever restarts happen (ipop, bipop and their sep
+    // variants). See https://github.com/CMA-ES/libcmaes/issues/258 and cpp-tests/test_fevals_mismatch.cpp.
     const char *res_names[] = {"x", "y", "edm", "time", "status_code", "status_msg"};
     SEXP s_res = RC_list_create_withnames_PROTECT(6, res_names);
     SEXP s_res_x = RC_dblvec_create_init_PROTECT(best_x.size(), best_x.data());
@@ -307,7 +309,6 @@ extern "C" SEXP c_cmaes_wrap(SEXP s_obj, SEXP s_x0, SEXP s_lower, SEXP s_upper, 
     RC_list_set_el_dblscalar(s_res, 3, sols.elapsed_time() / 1000.0); // in secs
     RC_list_set_el_intscalar(s_res, 4, sols.run_status());
     RC_list_set_el_string(s_res, 5, sols.status_msg().c_str());
-    // RC_list_set_el_intscalar(s_res, 6, sols.fevals());
     UNPROTECT(2); // s_res, s_res_x
     return s_res;
   } catch (const libcmaesr_error &e) {

--- a/tests/testthat/test_batch.R
+++ b/tests/testthat/test_batch.R
@@ -1,5 +1,4 @@
 res_names = c("x", "y", "edm", "time", "status_code", "status_msg")
-#res_names = c("x", "y", "edm", "time", "status_code", "status_msg", "fevals")
 
 eval_log = NULL
 
@@ -60,8 +59,6 @@ test_that("cmaes finds minimum of sphere function", {
         expect_gt(nrow(ee), 0)
         expect_equal(ncol(ee), dim + 1, info = ctx) # dim cols for x + 1 for y
         expect_true(nrow(ee) <= fevals + 20, info = ctx) # last pop could be over fevals
-        # FIXME: remove this once libcmaes is fixed
-        #expect_equal(res$fevals, nrow(ee), info = ctx)
 
         # all x-evaluations must be within [lower, upper]
         ee$y = NULL

--- a/tests/testthat/test_single.R
+++ b/tests/testthat/test_single.R
@@ -1,7 +1,6 @@
 eval_log = NULL
 
 res_names = c("x", "y", "edm", "time", "status_code", "status_msg")
-#res_names = c("x", "y", "edm", "time", "status_code", "status_msg", "fevals")
 
 # helper to create a logged sphere objective with lambda-aware argument checks
 make_logged_sphere_single = function(dim, lambda, lower = rep(-1, dim), upper = rep(1, dim), x0 = rep(0.5, dim)) {
@@ -46,8 +45,6 @@ test_that("single: finds minimum of sphere function", {
         expect_gt(nrow(ee), 0)
         expect_equal(ncol(ee), dim + 1) # dim cols for x + 1 for y
         expect_true(nrow(ee) <= fevals + 20, info = ctx) # last pop could be over fevals
-        # FIXME: reenable this once libcmaes is fixed
-        #expect_equal(res$fevals, nrow(ee), info = ctx)
 
         # all x-evaluations must be within [lower, upper]
         ee$y = NULL


### PR DESCRIPTION
Addresses item 9 of the package review: commented-out code strewn across the codebase.

The `fevals` remnants existed in five places because libcmaes undercounts the evaluation count whenever restarts happen (the returned `CMASolutions` is the "best run" snapshot, carrying only that run's local `_nevals`), so the field was never exposed to R:

- `src/cmaes_wrap.cpp` — commented `res_names` entry and `RC_list_set_el_intscalar` call
- `R/cmaes.R` — the `@return` entry for `fevals`, demoted to plain `#` comments
- `tests/testthat/test_single.R` and `test_batch.R` — a commented `res_names` and a commented `expect_equal(res$fevals, ...)` in each

All five are replaced by one note at the result-list construction in `cmaes_wrap.cpp`, pointing at the upstream issue (CMA-ES/libcmaes#258) and the existing reproduction in `cpp-tests/test_fevals_mismatch.cpp`.

The `rc_helpers.c:23-49` block also named in item 9 was already removed by #6.

No user-facing change, so no `NEWS.md` bullet. The roxygen lines removed were plain `#` comments, not `#'`, so `man/` is unchanged.

## Test plan

`devtools::test(filter = '^(single|batch)')` — 1792 passing, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)