### PR TITLE
fix: preserve exception messages and avoid longjmp in batch dispatch

### DIFF
--- a/src/cmaes_wrap.cpp
+++ b/src/cmaes_wrap.cpp
@@ -209,7 +209,8 @@ static CMASolutions dispatch_with_batch_eval(MyCMAParameters &cmaparams, SEXP s_
     return run_with_batch_eval(strat, s_obj);
   }
   default:
-    Rf_error("Unknown CMA-ES variant specified.");
+    // throw instead of Rf_error: a longjmp here would skip the destructor of the live cachedFF
+    throw libcmaesr_error(libcmaesr_errcode::unknown, "libcmaesr: unknown CMA-ES variant specified");
   }
 
   // not reached
@@ -318,6 +319,9 @@ extern "C" SEXP c_cmaes_wrap(SEXP s_obj, SEXP s_x0, SEXP s_lower, SEXP s_upper, 
     return s_res;
   } catch (const libcmaesr_error &e) {
     Rf_error("%s", e.what());
+  } catch (const std::exception &e) {
+    // eigen asserts, bad_alloc, libcmaes-internal throws; keep the original message
+    Rf_error("libcmaesr: %s", e.what());
   } catch (...) {
     Rf_error("libcmaesr: unknown error");
   }


### PR DESCRIPTION
Fixes item 12 of the package review: exception handling loses information and has a longjmp over a live destructor.

## Changes

**`c_cmaes_wrap` swallowed exception messages.** The `catch (...)` fallback reported `"libcmaesr: unknown error"` for every `std::exception` — Eigen asserts, `std::bad_alloc`, any libcmaes-internal throw. A `catch (const std::exception &e)` handler is now placed between the `libcmaesr_error` handler and the catch-all, forwarding `e.what()`. The `libcmaesr_error` handler still comes first, so its messages (which already carry the `libcmaesr:` prefix) are unchanged.

**`dispatch_with_batch_eval` used `Rf_error` in its default case.** `Rf_error` longjmps, skipping the destructor of the live `std::function cachedFF` on the stack — the exact failure mode the `libcmaesr_error` machinery exists to prevent. It now throws `libcmaesr_error`, so the error is raised by the single `Rf_error` at the R boundary after the stack unwinds properly.

## Testing

No new tests: both paths are defensive and unreachable from R. `algo` is validated against `cmaes_algos` in `cmaes_control()` and re-checked in `cmaes()`, and libcmaes's `set_str_algo()` leaves `_algo` at its previous value for an unknown string rather than producing an unmapped one, so the `default` case cannot be entered. The `std::exception` path needs an allocation failure or internal library throw, which cannot be provoked reliably in a test.

Existing suite passes unchanged: `FAIL 0 | WARN 0 | SKIP 0 | PASS 1792`. The package compiles with no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)